### PR TITLE
update Inkscape.rb to point to the 0.92 branch

### DIFF
--- a/Formula/inkscape.rb
+++ b/Formula/inkscape.rb
@@ -7,9 +7,12 @@ class Inkscape < Formula
   revision 1
 
   head do
-    url "lp:inkscape/0.92.x", :using => :bzr
+    url "lp:inkscape", :using => :bzr
+    url "lp:inkscape/0.92.x", :using => :bzr if build.include? "branch-0.92"
   end
-  
+
+  option "branch-0.92", "When used with --HEAD, build from the 0.92.x branch"
+
   option "with-gtk3", "Build Inkscape with GTK+3 (Experimental)"
 
   depends_on "autoconf" => :build

--- a/Formula/inkscape.rb
+++ b/Formula/inkscape.rb
@@ -7,9 +7,9 @@ class Inkscape < Formula
   revision 1
 
   head do
-    url "lp:inkscape", :using => :bzr
+    url "lp:inkscape/0.92.x", :using => :bzr
   end
-
+  
   option "with-gtk3", "Build Inkscape with GTK+3 (Experimental)"
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
It looks like the trunk of Inkscape is not where release work happens ;-)

I've changed the file locally with that change and successfully built the latest 0.92.x using `brew install caskformula/caskformula/inkscape --with-poppler --HEAD`