### PR TITLE
Reenabled gtk3 option for cmake build system

### DIFF
--- a/Formula/inkscape.rb
+++ b/Formula/inkscape.rb
@@ -60,7 +60,7 @@ class Inkscape < Formula
 
     system "mkdir", "build"
     Dir.chdir("build")
-    system "cmake", "..", *std_cmake_args
+    system "cmake", "..", ("-DWITH_GTK3_EXPERIMENTAL=ON" if build.with? "gtk3"), *std_cmake_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
It seems like the switch to cmake building destroyed the option --with-gtk3. This patch adds it back in, but I have very little experience in Homebrew formulas (and Ruby) so I don't know if it brakes the regular one.